### PR TITLE
Update GitHub URL

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer id="footer">
   <ul class="icons">
     <li><a href="http://twitter.com/olemchls" class="icon fa-twitter"><span class="label">Twitter</span></a></li>
-    <li><a href="https://github.com/nesQuick" class="icon fa-github-square"><span class="label">GitHub</span></a></li>
+    <li><a href="https://github.com/OleMchls" class="icon fa-github-square"><span class="label">GitHub</span></a></li>
     <li><a href="https://www.facebook.com/#/Ole.H.Michaelis" class="icon fa-facebook"><span class="label">Facebook</span></a></li>
     <li><a href="https://instagram.com/olemichaelis/" class="icon fa-instagram"><span class="label">Instagram</span></a></li>
     <li><a href="mailto: info@slidr.io" class="icon fa-envelope-o"><span class="label">Email</span></a></li>


### PR DESCRIPTION
The GitHub URL in your site's footer links to somebody else's GitHub profile. This PR fixes that.